### PR TITLE
Add link repost tracker

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/vapor/bcrypt.git",
         "state": {
           "branch": null,
-          "revision": "3ee4aca16ba6ebfb1ad48cc5fd4dfb163c6d6be8",
-          "version": "1.1.0"
+          "revision": "a36b6f0381f2edb9fb32b8882ebc801ba8db10ef",
+          "version": "1.1.1"
         }
       },
       {
@@ -15,17 +15,17 @@
         "repositoryURL": "https://github.com/vapor/bits.git",
         "state": {
           "branch": null,
-          "revision": "c32f5e6ae2007dccd21a92b7e33eba842dd80d2f",
-          "version": "1.1.0"
+          "revision": "03079476b04139a8b744ad96f975176df5ae12bc",
+          "version": "1.1.1"
         }
       },
       {
         "package": "Chameleon",
-        "repositoryURL": "https://github.com/ChameleonBot/Chameleon.git",
+        "repositoryURL": "https://github.com/maxgoedjen/Chameleon.git",
         "state": {
-          "branch": null,
-          "revision": "14dd96bd8edf87c2949868d9840278f55082ce1c",
-          "version": "0.0.1"
+          "branch": "maxg.permalink",
+          "revision": "ef22798d9815e357326e0de57275cf64f2332921",
+          "version": null
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/vapor/console.git",
         "state": {
           "branch": null,
-          "revision": "df9eb9a6afd03851abcb3d8204d04c368729776e",
-          "version": "2.3.0"
+          "revision": "78d27da2838aa2fb0354037e71a589583d166b41",
+          "version": "2.3.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/vapor/core.git",
         "state": {
           "branch": null,
-          "revision": "f9f3a585ab0ea5764b46d7a36d9c0d9d508b9c63",
-          "version": "2.2.0"
+          "revision": "aa15871311b497a24a7f0e96b1ae6865dd600818",
+          "version": "2.2.1"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/vapor/crypto.git",
         "state": {
           "branch": null,
-          "revision": "bf4470b9da79024aab79c85de80374f6c29e3864",
-          "version": "2.1.1"
+          "revision": "95e96b4d8e5c81da850db512a2fde167548f9094",
+          "version": "2.1.3"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/vapor/ctls.git",
         "state": {
           "branch": null,
-          "revision": "fddec6a4643d6e85b6bb6dc54b1b5cdbabd395d2",
-          "version": "1.1.2"
+          "revision": "fba1297f4986a4dac8b02f7ac4e84a77fd492e4c",
+          "version": "1.1.3"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/vapor/debugging.git",
         "state": {
           "branch": null,
-          "revision": "49c5e8f0a7cb5456a8f7c72c6cd9f1553e5885a8",
-          "version": "1.1.0"
+          "revision": "fc5a27d6eb236141dc24e5f14eedaa2e035ae7b3",
+          "version": "1.1.1"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/vapor/engine.git",
         "state": {
           "branch": null,
-          "revision": "decf702d774ac630dfe0441ff76b4bb68257b77a",
-          "version": "2.2.1"
+          "revision": "e44822c7516676d8bcb0141a6e248a88847b110c",
+          "version": "2.2.5"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/vapor/json.git",
         "state": {
           "branch": null,
-          "revision": "735800d8f2e75ebe3be25559eb6a781f4666dcfc",
-          "version": "2.2.1"
+          "revision": "6c7ce40d30b322d45cc49a8f1d742609d3228eb7",
+          "version": "2.2.2"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/vapor/multipart.git",
         "state": {
           "branch": null,
-          "revision": "8e541b2e6fc64a3741eca2aa48ee2c3f23cbe17c",
-          "version": "2.1.1"
+          "revision": "1d98ad2205d0620fe2801048f76420572281e6e8",
+          "version": "2.2.1"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/vapor/node.git",
         "state": {
           "branch": null,
-          "revision": "642f357d08ec5aa335ae2e3c4633c72da7b5a0c4",
-          "version": "2.1.1"
+          "revision": "607aa595081da496f0f04a5c0cffd976e81d2e4e",
+          "version": "2.1.5"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/vapor/redis.git",
         "state": {
           "branch": null,
-          "revision": "525df8967447366c77a833a55b985c6c8735307e",
-          "version": "2.1.0"
+          "revision": "42cb0a0a0b757eff30005adeead82ce0f718e566",
+          "version": "2.2.0"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/vapor/routing.git",
         "state": {
           "branch": null,
-          "revision": "cb9d78aca2540c1a6b45b0ab43e5b0c50f29d216",
-          "version": "2.2.0"
+          "revision": "e950f3d56fb2eab6a64dafcfdb89ac98866045b8",
+          "version": "2.2.1"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/vapor/sockets.git",
         "state": {
           "branch": null,
-          "revision": "70d14c0e223257176f5ef69a595f7cad5de7a88b",
-          "version": "2.2.1"
+          "revision": "79fc180cdcb451dbbb01b1156be36720adde80e0",
+          "version": "2.2.3"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/vapor/tls.git",
         "state": {
           "branch": null,
-          "revision": "6c6eedb6761cddc6b6c87142a27eec13fa1701ec",
-          "version": "2.1.1"
+          "revision": "a5981b0a370f227521330beb92b7ce6d636a1eb2",
+          "version": "2.1.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "SlackBotKit", targets: ["SlackBotKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ChameleonBot/Chameleon.git", .upToNextMinor(from: "0.0.0")),
+        .package(url: "https://github.com/maxgoedjen/Chameleon.git", .branch("maxg.permalink")),
     ],
     targets: [
         .target(name: "SlackBot", dependencies: ["SlackBotKit"]),

--- a/Sources/SlackBot/main.swift
+++ b/Sources/SlackBot/main.swift
@@ -15,7 +15,7 @@ let authenticator = OAuthAuthenticator(
 
 let bot = SlackBot(
     authenticator: authenticator,
-    services: [KarmaService(storage: storage)]
+    services: [KarmaService(storage: storage), CamillinkService(storage: storage)]
 )
 
 bot.on(message.self) { bot, data in

--- a/Sources/SlackBotKit/Camillink/Camillink+Config.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+Config.swift
@@ -1,26 +1,26 @@
 
 extension CamillinkService {
-    
+
     public struct Config {
-        
+
         // How many days have to have passed before a prompt. No limit if nil.
         let recencyLimitInDays: Int?
-        
+
         // Whether camille should prompt if a message has a link and a reference to the channel it was originally posted in.
         // eg: "hey check out http://example.com that's being discussed in #exampletalk
         // if true, do not post a message
         let silentCrossLink: Bool
-        
+
         // Whether camille should prompt if a message has a link that was posted earlier in the same channel.
         // if true, do not post a message when a link is in the same channel
         let silentSameChannel: Bool
-        
+
         public init(recencyLimitInDays: Int?, silentCrossLink: Bool, silentSameChannel: Bool) {
             self.recencyLimitInDays = recencyLimitInDays
             self.silentCrossLink = silentCrossLink
             self.silentSameChannel = silentSameChannel
         }
-        
+
         public static func `default`() -> Config {
             return Config(
                 recencyLimitInDays: nil,
@@ -30,3 +30,4 @@ extension CamillinkService {
         }
     }
 }
+

--- a/Sources/SlackBotKit/Camillink/Camillink+Config.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+Config.swift
@@ -1,0 +1,19 @@
+
+extension CamillinkService {
+    
+    public struct Config {
+        
+        // How many days have to have passed before a prompt. No limit if nil.
+        let recencyLimitInDays: Int?
+        
+        public init(recencyLimitInDays: Int?) {
+            self.recencyLimitInDays = recencyLimitInDays
+        }
+        
+        public static func `default`() -> Config {
+            return Config(
+                recencyLimitInDays: nil
+            )
+        }
+    }
+}

--- a/Sources/SlackBotKit/Camillink/Camillink+Config.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+Config.swift
@@ -6,13 +6,26 @@ extension CamillinkService {
         // How many days have to have passed before a prompt. No limit if nil.
         let recencyLimitInDays: Int?
         
-        public init(recencyLimitInDays: Int?) {
+        // Whether camille should prompt if a message has a link and a reference to the channel it was originally posted in.
+        // eg: "hey check out http://example.com that's being discussed in #exampletalk
+        // if true, do not post a message
+        let silentCrossLink: Bool
+        
+        // Whether camille should prompt if a message has a link that was posted earlier in the same channel.
+        // if true, do not post a message when a link is in the same channel
+        let silentSameChannel: Bool
+        
+        public init(recencyLimitInDays: Int?, silentCrossLink: Bool, silentSameChannel: Bool) {
             self.recencyLimitInDays = recencyLimitInDays
+            self.silentCrossLink = silentCrossLink
+            self.silentSameChannel = silentSameChannel
         }
         
         public static func `default`() -> Config {
             return Config(
-                recencyLimitInDays: nil
+                recencyLimitInDays: nil,
+                silentCrossLink: true,
+                silentSameChannel: true
             )
         }
     }

--- a/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
@@ -50,12 +50,15 @@ extension CamillinkService {
     }
 
     func shouldSilence(message: MessageDecorator, record: Record) throws -> Bool {
-        return try shouldSilenceForWhitelisting(record: record) ||
+        return shouldSilenceForWhitelisting(record: record) ||
             shouldSilenceForCrossLink(message: message, record: record) ||
             shouldSilenceForSameChannel(message: message, record: record)
     }
 
     func shouldSilenceForWhitelisting(record: Record) -> Bool {
+        // Eventually implement whitelisting here
+        // This is WIP until I get time to implement attachments
+        // in Chameleon
         return false
     }
 

--- a/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
@@ -10,16 +10,30 @@ extension CamillinkService {
         guard let linkURL = URL(string: linkString) else { return }
         guard try !isLinkWhitelisted(link: linkURL) else { return }
         if let previous = try previousLinkDiscussion(linkURL: linkURL) {
-            try sendPrompt(bot: bot, message: message, linkURL: linkURL, previousLink: previous)
+            try sendPrompt(bot: bot, message: message, linkURL: linkURL, previousLink: previous.permalink)
         } else {
-            try markPreviousDiscussion(message: message, linkURL: linkURL)
+            try markPreviousDiscussion(bot: bot, message: message, linkURL: linkURL)
         }
 
     }
     
-    func previousLinkDiscussion(linkURL: URL) throws -> URL? {
-        let urlString: String = try storage.get(key: linkURL.absoluteString, from: Keys.namespace, or: "INVALID")
-        return URL(string: urlString)
+    func previousLinkDiscussion(linkURL: URL) throws -> Record? {
+        let string = try storage.get(key: linkURL.absoluteString, from: Keys.namespace, or: "INVALID")
+        guard let data = string.data(using: .utf8) else { return nil }
+        let record = try JSONDecoder().decode(Record.self, from: data)
+        if let dayLimit = config.recencyLimitInDays {
+            // Dave please don't yell at me
+            guard let daysSince = Calendar.current.dateComponents([.day], from: record.date, to: Date()).day else { return nil }
+            if dayLimit > daysSince {
+                return record
+            } else {
+                // Past limit, remove it
+                storage.remove(key: linkURL.absoluteString, from: Keys.namespace)
+                return nil
+            }
+        } else {
+            return record
+        }
     }
     
     func sendPrompt(bot: SlackBot, message: MessageDecorator, linkURL: URL, previousLink: URL) throws {
@@ -31,10 +45,15 @@ extension CamillinkService {
         try bot.send(response.makeChatMessage())
     }
     
-    func markPreviousDiscussion(message: MessageDecorator, linkURL: URL    ) throws {
+    func markPreviousDiscussion(bot: SlackBot, message: MessageDecorator, linkURL: URL) throws {
         guard let channel = message.message.channel else { return }
-        // TODO: MAXG pending Chameleon change to get permalink
-//        storage.set(value: channel.id, forKey: linkURL.absoluteString, in: Keys.namespace)
+        let permalink = try bot.permalink(message.message)
+        guard let permalinkURL = URL(string: permalink) else { return }
+        let record = Record(channelID: channel.id, permalink: permalinkURL)
+        // Hack since Storage only takes strings for the moment
+        let data = try JSONEncoder().encode(record)
+        guard let string = String(data: data, encoding: .utf8) else { return }
+        storage.set(value: string, forKey: linkURL.absoluteString, in: Keys.namespace)
     }
     
     func isLinkWhitelisted(link: URL) throws -> Bool {

--- a/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
@@ -1,0 +1,44 @@
+import Chameleon
+import Foundation
+
+extension CamillinkService {
+    
+    func trackLink(bot: SlackBot, message: MessageDecorator) throws {
+        guard !message.isIM else { return }
+        guard let linkString = message.mentionedLinks.first.value?.value.link else { return }
+        // Might be good to clean attribution links to prevent duplicates, etc...
+        guard let linkURL = URL(string: linkString) else { return }
+        guard try !isLinkWhitelisted(link: linkURL) else { return }
+        if let previous = try previousLinkDiscussion(linkURL: linkURL) {
+            try sendPrompt(bot: bot, message: message, linkURL: linkURL, previousLink: previous)
+        } else {
+            try markPreviousDiscussion(message: message, linkURL: linkURL)
+        }
+
+    }
+    
+    func previousLinkDiscussion(linkURL: URL) throws -> URL? {
+        let urlString: String = try storage.get(key: linkURL.absoluteString, from: Keys.namespace, or: "INVALID")
+        return URL(string: urlString)
+    }
+    
+    func sendPrompt(bot: SlackBot, message: MessageDecorator, linkURL: URL, previousLink: URL) throws {
+        let response = try message.respond()
+        let comment = "👋 \(linkURL.absoluteString) is already being discussed here: \(previousLink.absoluteString)"
+        response
+            .text([comment])
+            .newLine()
+        try bot.send(response.makeChatMessage())
+    }
+    
+    func markPreviousDiscussion(message: MessageDecorator, linkURL: URL    ) throws {
+        guard let channel = message.message.channel else { return }
+        // TODO: MAXG pending Chameleon change to get permalink
+//        storage.set(value: channel.id, forKey: linkURL.absoluteString, in: Keys.namespace)
+    }
+    
+    func isLinkWhitelisted(link: URL) throws -> Bool {
+        return false
+    }
+
+}

--- a/Sources/SlackBotKit/Camillink/Camillink+Patterns.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+Patterns.swift
@@ -1,9 +1,9 @@
 import Chameleon
 
 extension CamillinkService {
-    
+
     enum Patterns: PatternRepresentable {
-        
+
         case http
 
         var pattern: [Matcher] {
@@ -15,3 +15,4 @@ extension CamillinkService {
         var strict: Bool { return false }
     }
 }
+

--- a/Sources/SlackBotKit/Camillink/Camillink+Patterns.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+Patterns.swift
@@ -1,0 +1,17 @@
+import Chameleon
+
+extension CamillinkService {
+    
+    enum Patterns: PatternRepresentable {
+        
+        case http
+
+        var pattern: [Matcher] {
+            switch self {
+            case .http: return [String.any.orNone, "<http", "s".orNone, "://", String.any, ">"]
+            }
+        }
+
+        var strict: Bool { return false }
+    }
+}

--- a/Sources/SlackBotKit/Camillink/Camillink+Storage.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+Storage.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension CamillinkService {
+    
+    public struct Record: Codable {
+        
+        let date: Date
+        let channelID: String
+        let permalink: URL
+        
+        init(channelID: String, permalink: URL){
+            self.date = Date()
+            self.channelID = channelID
+            self.permalink = permalink
+        }
+        
+    }
+}

--- a/Sources/SlackBotKit/Camillink/Camillink+Storage.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+Storage.swift
@@ -1,18 +1,19 @@
 import Foundation
 
 extension CamillinkService {
-    
+
     public struct Record: Codable {
-        
+
         let date: Date
         let channelID: String
         let permalink: URL
-        
+
         init(channelID: String, permalink: URL){
             self.date = Date()
             self.channelID = channelID
             self.permalink = permalink
         }
-        
+
     }
 }
+

--- a/Sources/SlackBotKit/Camillink/Camillink.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink.swift
@@ -1,0 +1,29 @@
+import Chameleon
+
+public final class CamillinkService: SlackBotMessageService {
+    // MARK: - Properties
+    let storage: Storage
+    let config: Config
+
+    enum Keys {
+        static let namespace = "Camillink"
+        static let count = "count"
+        static let user = "user"
+    }
+
+    // MARK: - Lifecycle
+    public init(config: Config = Config.default(), storage: Storage) {
+        self.config = config
+        self.storage = storage
+    }
+
+    // MARK: - Public Functions
+    public func configure(slackBot: SlackBot) {
+        configureMessageService(slackBot: slackBot)
+    }
+
+    public func onMessage(slackBot: SlackBot, message: MessageDecorator, previous: MessageDecorator?) throws {
+        try trackLink(bot: slackBot, message: message)
+    }
+
+}


### PR DESCRIPTION
Adds a feature to Camille to let people know if a link is already being discussed in a different channel.

<img width="572" alt="image" src="https://user-images.githubusercontent.com/342665/58394982-d98da100-7ffa-11e9-8e4d-793ecfada4cc.png">