### PR TITLE
Thread response, disable link unfurling, and give channel link a label

### DIFF
--- a/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
@@ -37,17 +37,18 @@ extension CamillinkService {
         let response = try message.respond(.threaded)
 
         response
-            .text([comment(linkURL: linkURL, previousMessagePermalink: previousMessagePermalink)])
+            .text([previousConversationComment(for: linkURL, at: previousMessagePermalink)])
             .newLine()
         try bot.send(response.makeChatMessage())
     }
 
-    func comment(linkURL: URL, previousMessagePermalink: URL) -> String {
+    func previousConversationComment(for linkURL: URL, at previousMessagePermalink: URL) -> String {
         let linkURLString = linkURL.absoluteString
 
-        var comment = "👋 That <\(linkURLString)|link> is already being discussed <\(previousMessagePermalink.absoluteString)|here>"
+        var comment = "👋 That <\(linkURLString)|link> is already being discussed at <\(previousMessagePermalink.absoluteString)|this message>"
 
-        // Add channel mention
+        // Add channel mention, if we update the storage model we should add the channel as a property
+        // instead of relying on parsing the permalink parsing
         let pathComponents = previousMessagePermalink.pathComponents
         if let channel = pathComponents.last(where: { $0.starts(with: "C") && $0.count == 9 }) {
             comment += " in <#\(channel)>"

--- a/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
@@ -33,12 +33,12 @@ extension CamillinkService {
     }
 
     func sendPrompt(bot: SlackBot, message: MessageDecorator, linkURL: URL, previousLink: URL) throws {
-        let response = try message.respond()
-        let comment = "👋 \(linkURL.absoluteString) is already being discussed here: \(previousLink.absoluteString)"
+        let response = try message.respond(.threaded)
+        let comment = "👋 \(linkURL.absoluteString) is already being discussed <\(previousLink.absoluteString)|here>"
         response
             .text([comment])
             .newLine()
-        try bot.send(response.makeChatMessage())
+        try bot.send(response.makePreviousDiscussionChatMessage())
     }
 
     func markPreviousDiscussion(bot: SlackBot, message: MessageDecorator, linkURL: URL) throws {
@@ -89,3 +89,26 @@ extension CamillinkService {
 
 }
 
+private extension ChatMessageDecorator {
+
+    func makePreviousDiscussionChatMessage() throws -> ChatMessage {
+        let source = try makeChatMessage()
+
+        return ChatMessage(
+            response_url: source.response_url,
+            channel: source.channel,
+            text: source.text,
+            parse: source.parse,
+            link_names: source.link_names,
+            unfurl_links: false,
+            unfurl_media: false,
+            username: source.username,
+            as_user: source.as_user,
+            icon_url: source.icon_url,
+            icon_emoji: source.icon_emoji,
+            thread_ts: source.thread_ts,
+            reply_broadcast: source.reply_broadcast,
+            attachments: source.attachments
+        )
+    }
+}

--- a/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
@@ -34,7 +34,8 @@ extension CamillinkService {
 
     func sendPrompt(bot: SlackBot, message: MessageDecorator, currentLinkURL: URL, record: Record) throws {
         let response = try message.respond(.threaded)
-        let comment = "👋 That <\(currentLinkURL.absoluteString)|link> is already being discussed in <\(record.permalink.absoluteString)|this message> in <#\(record.channelID)>"
+        let comment = "👋 That <\(currentLinkURL.absoluteString)|link> is already being discussed in "
+            + "<\(record.permalink.absoluteString)|this message> in <#\(record.channelID)>"
         response
             .text([comment])
             .newLine()

--- a/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+LinkMention.swift
@@ -34,9 +34,7 @@ extension CamillinkService {
 
     func sendPrompt(bot: SlackBot, message: MessageDecorator, currentLinkURL: URL, record: Record) throws {
         let response = try message.respond(.threaded)
-
         let comment = "👋 That <\(currentLinkURL.absoluteString)|link> is already being discussed in <\(record.permalink.absoluteString)|this message> in <#\(record.channelID)>"
-
         response
             .text([comment])
             .newLine()
@@ -90,3 +88,4 @@ extension CamillinkService {
     }
 
 }
+


### PR DESCRIPTION
Like the PR title says

<img width="1087" alt="Screen Shot 2019-06-05 at 8 12 33 PM" src="https://user-images.githubusercontent.com/8225090/59000061-6cce8f80-87ce-11e9-80a7-e04e22d00b59.png">
