### PR TITLE
Removed CaseIterable usage

### DIFF
--- a/Sources/SlackBotKit/AutoModerator/AutoModeratorService+Phrases.swift
+++ b/Sources/SlackBotKit/AutoModerator/AutoModeratorService+Phrases.swift
@@ -2,11 +2,13 @@
 extension AutoModeratorService {
     typealias Responses = [String]
 
-    enum TriggerPhrase: String, CaseIterable {
+    enum TriggerPhrase: String {
         case youGuys = "you guys"
         case thanksGuys = "thanks guys"
         case hiGuys = "hi guys"
         case heyGuys = "hey guys"
+
+        static let all: [TriggerPhrase] = [.youGuys, .thanksGuys, .hiGuys, .heyGuys]
     }
     
     enum AutoModeratorError: Error {

--- a/Sources/SlackBotKit/AutoModerator/AutoModeratorService.swift
+++ b/Sources/SlackBotKit/AutoModerator/AutoModeratorService.swift
@@ -30,7 +30,7 @@ public final class AutoModeratorService: SlackBotMessageService {
 
     func containsTriggerPhrase(_ messageText: String) -> TriggerPhrase? {
         return TriggerPhrase
-            .allCases
+            .all
             .first(where: { messageText.contains($0.rawValue) })
     }
 }


### PR DESCRIPTION
- Downgraded CaseIterable usage to a local property until Camille is upgraded to use Swift 5
- Decided to go with a custom `all` property to reduce potential conflicts in the future. As soon as we bump Camille to Swift 5 we should move this back to `CaseIterable` and remove the `all` property