### PR TITLE
Long Requested Camille Improvements

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,57 +2,39 @@
   "object": {
     "pins": [
       {
+        "package": "async-http-client",
+        "repositoryURL": "https://github.com/swift-server/async-http-client.git",
+        "state": {
+          "branch": null,
+          "revision": "7a4dfe026f6ee0f8ad741b58df74c60af296365d",
+          "version": "1.9.0"
+        }
+      },
+      {
+        "package": "async-kit",
+        "repositoryURL": "https://github.com/vapor/async-kit.git",
+        "state": {
+          "branch": null,
+          "revision": "e2f741640364c1d271405da637029ea6a33f754e",
+          "version": "1.11.1"
+        }
+      },
+      {
         "package": "Chameleon",
         "repositoryURL": "https://github.com/ChameleonBot/Chameleon.git",
         "state": {
           "branch": "revamp",
-          "revision": "ab61e3c193673032f756e1a31fa1e0b08a890087",
+          "revision": "e0dc9bbd88977fcb5f7ab306211379994124250c",
           "version": null
         }
       },
       {
-        "package": "Console",
-        "repositoryURL": "https://github.com/vapor/console.git",
+        "package": "console-kit",
+        "repositoryURL": "https://github.com/vapor/console-kit.git",
         "state": {
           "branch": null,
-          "revision": "74cfbea629d4aac34a97cead2447a6870af1950b",
-          "version": "3.1.1"
-        }
-      },
-      {
-        "package": "Core",
-        "repositoryURL": "https://github.com/vapor/core.git",
-        "state": {
-          "branch": null,
-          "revision": "1782c550512dc5a43d0bca405e28fc386d932bbf",
-          "version": "3.10.0"
-        }
-      },
-      {
-        "package": "Crypto",
-        "repositoryURL": "https://github.com/vapor/crypto.git",
-        "state": {
-          "branch": null,
-          "revision": "df8eb7d8ae51787b3a0628aa3975e67666da936c",
-          "version": "3.3.3"
-        }
-      },
-      {
-        "package": "DatabaseKit",
-        "repositoryURL": "https://github.com/vapor/database-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "8f352c8e66dab301ab9bfef912a01ce1361ba1e4",
-          "version": "1.3.3"
-        }
-      },
-      {
-        "package": "HTTP",
-        "repositoryURL": "https://github.com/vapor/http.git",
-        "state": {
-          "branch": null,
-          "revision": "fba1329cd430e2f9a3f995b317b04f268d8b2978",
-          "version": "3.3.2"
+          "revision": "75ea3b627d88221440b878e5dfccc73fd06842ed",
+          "version": "4.2.7"
         }
       },
       {
@@ -60,44 +42,80 @@
         "repositoryURL": "https://github.com/mxcl/LegibleError.git",
         "state": {
           "branch": null,
-          "revision": "c615c01e461e8a3495ba4ea75f5d671c76820105",
-          "version": "1.0.1"
+          "revision": "bc596702d7ff618c3f90ba480eeb48b3e83a2fbe",
+          "version": "1.0.6"
         }
       },
       {
-        "package": "Multipart",
-        "repositoryURL": "https://github.com/vapor/multipart.git",
+        "package": "multipart-kit",
+        "repositoryURL": "https://github.com/vapor/multipart-kit.git",
         "state": {
           "branch": null,
-          "revision": "a7e0db512ff7eee7cd91d0a69dfeeec36f74d604",
-          "version": "3.1.2"
+          "revision": "2dd9368a3c9580792b77c7ef364f3735909d9996",
+          "version": "4.5.1"
         }
       },
       {
-        "package": "Redis",
+        "package": "redis",
         "repositoryURL": "https://github.com/vapor/redis.git",
         "state": {
           "branch": null,
-          "revision": "b6c0c98d2219f550ccf23c4bb8f8b14d75356bc6",
-          "version": "3.4.0"
+          "revision": "e955843b08064071f465a6b1ca9e04bebad8623a",
+          "version": "4.6.0"
         }
       },
       {
-        "package": "Routing",
-        "repositoryURL": "https://github.com/vapor/routing.git",
+        "package": "RediStack",
+        "repositoryURL": "https://gitlab.com/mordil/RediStack.git",
         "state": {
           "branch": null,
-          "revision": "d76f339c9716785e5079af9d7075d28ff7da3d92",
-          "version": "3.1.0"
+          "revision": "b277715a02ec3273ede16c2669a5e240fcb4d6b9",
+          "version": "1.2.2"
         }
       },
       {
-        "package": "Service",
-        "repositoryURL": "https://github.com/vapor/service.git",
+        "package": "routing-kit",
+        "repositoryURL": "https://github.com/vapor/routing-kit.git",
         "state": {
           "branch": null,
-          "revision": "fa5b5de62bd68bcde9a69933f31319e46c7275fb",
-          "version": "1.0.2"
+          "revision": "5603b81ceb744b8318feab1e60943704977a866b",
+          "version": "4.3.1"
+        }
+      },
+      {
+        "package": "swift-backtrace",
+        "repositoryURL": "https://github.com/swift-server/swift-backtrace.git",
+        "state": {
+          "branch": null,
+          "revision": "d3e04a9d4b3833363fb6192065b763310b156d54",
+          "version": "1.3.1"
+        }
+      },
+      {
+        "package": "swift-crypto",
+        "repositoryURL": "https://github.com/apple/swift-crypto.git",
+        "state": {
+          "branch": null,
+          "revision": "067254c79435de759aeef4a6a03e43d087d61312",
+          "version": "2.0.5"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
+        }
+      },
+      {
+        "package": "swift-metrics",
+        "repositoryURL": "https://github.com/apple/swift-metrics.git",
+        "state": {
+          "branch": null,
+          "revision": "eadb828f878fed144387e3845866225bb7082c56",
+          "version": "2.3.0"
         }
       },
       {
@@ -105,8 +123,26 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "8da5c5a4e6c5084c296b9f39dc54f00be146e0fa",
-          "version": "1.14.2"
+          "revision": "d6e3762e0a5f7ede652559f53623baf11006e17c",
+          "version": "2.39.0"
+        }
+      },
+      {
+        "package": "swift-nio-extras",
+        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
+        "state": {
+          "branch": null,
+          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
+          "version": "1.10.2"
+        }
+      },
+      {
+        "package": "swift-nio-http2",
+        "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
+        "state": {
+          "branch": null,
+          "revision": "50c25c132b140e62b45e90b5a76f13ded02c8a46",
+          "version": "1.20.1"
         }
       },
       {
@@ -114,71 +150,35 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "0f3999f3e3c359cc74480c292644c3419e44a12f",
-          "version": "1.4.0"
+          "revision": "b5260a31c2a72a89fa684f5efb3054d8725a2316",
+          "version": "2.18.0"
         }
       },
       {
-        "package": "swift-nio-ssl-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-ssl-support.git",
+        "package": "swift-nio-transport-services",
+        "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "c02eec4e0e6d351cd092938cf44195a8e669f555",
-          "version": "1.0.0"
+          "revision": "8ab824b140d0ebcd87e9149266ddc353e3705a3e",
+          "version": "1.11.4"
         }
       },
       {
-        "package": "swift-nio-zlib-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
-        "state": {
-          "branch": null,
-          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
-          "version": "1.0.0"
-        }
-      },
-      {
-        "package": "TemplateKit",
-        "repositoryURL": "https://github.com/vapor/template-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "4370aa99c01fc19cc8272b67bf7204b2d2063680",
-          "version": "1.5.0"
-        }
-      },
-      {
-        "package": "URLEncodedForm",
-        "repositoryURL": "https://github.com/vapor/url-encoded-form.git",
-        "state": {
-          "branch": null,
-          "revision": "20f68fbe7fac006d4d0617ea4edcba033227359e",
-          "version": "1.1.0"
-        }
-      },
-      {
-        "package": "Validation",
-        "repositoryURL": "https://github.com/vapor/validation.git",
-        "state": {
-          "branch": null,
-          "revision": "4de213cf319b694e4ce19e5339592601d4dd3ff6",
-          "version": "2.1.1"
-        }
-      },
-      {
-        "package": "Vapor",
+        "package": "vapor",
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "642f3d4d1f0eafad651c85524d0d1c698b55399f",
-          "version": "3.3.3"
+          "revision": "5861bf9e2cff2c4cb0dcfb0c15ecfaa8bc5630e0",
+          "version": "4.55.3"
         }
       },
       {
-        "package": "WebSocket",
-        "repositoryURL": "https://github.com/vapor/websocket.git",
+        "package": "websocket-kit",
+        "repositoryURL": "https://github.com/vapor/websocket-kit.git",
         "state": {
           "branch": null,
-          "revision": "d85e5b6dce4d04065865f77385fc3324f98178f6",
-          "version": "1.1.2"
+          "revision": "e32033ad3c68ebec1b761bc961be7bd56bad02f8",
+          "version": "2.3.1"
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -4,19 +4,16 @@
 
 ### Set up the project
 
-- Clone the project
-- Install pkg-config if you don't already have it installed ( `brew install pkg-config` )
-- Set up vapor (`brew tap vapor/tap` & `brew install vapor/tap/vapor`)
-- Set up libressl (`brew install libressl` & `vapor update`)
-- Create the Xcode project with Swift Package Manager (`swift package generate-xcodeproj`)
+- Clone the project.
+- Double click Package.swift.
 -  [Create a Slack app](https://api.slack.com/apps). Click "Add features and functionality," and add the "Bots" feature.
 - Set up [ngrok](https://ngrok.com) for development. Run `ngrok http http://0.0.0.0:8080` to expose your local server to the internet.
 - Copy the URL ngrok gives you (it'll be something like `http://abc123.ngrok.io`). 
 - Go back to your Slack app's settings and add the ngrok URL in the Slack app permissions page under "Redirect URIs" with `/oauth` at the end of it (so, in our example, `http://abc123.ngrok.io/oauth`)
-- Set up [redis](https://redis.io). [Docker](https://docs.docker.com/docker-for-mac/install/) is an easy way to do this. If you have docker installed, run `docker run --name redis -p 6379:6379 -d redis`
+- If you're developing against the production version of Camille setup [redis](https://redis.io). [Docker](https://docs.docker.com/docker-for-mac/install/) is an easy way to do this. If you have docker installed, run `docker run --name redis -p 6379:6379 -d redis`. Otherwise you can use `MemoryStorage` in place of redis.
 - Set the project's environment variables. Click the scheme dropdown, and hit "edit scheme."
 - Set the `STORAGE_URL` environment variable to the redis URL (`redis://127.0.0.1:6379` by default)
-- Set `CLIENT_ID` and `CLIENT_SECRET` to the IDs that Slack shows on your App page.
+- Set `CLIENT_ID` and `CLIENT_SECRET` to the IDs that Slack shows on your App page. (Alternatively message @mergesort for some development credentials you can use for testing an integration.)
 - Set `REDIRECT_URI` to the redirect URL we set earlier ( `http://abc123.ngrok.io/oauth`, in our example)
 - Run the project
 - Visit `http://0.0.0.0:8080/login` and authorize the app.

--- a/Sources/SlackBotKit/AutoModerator/AutoModerator.swift
+++ b/Sources/SlackBotKit/AutoModerator/AutoModerator.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ChameleonKit
 
 /// A service that observes every message in a public channel, determines whether it requires an automatic moderator
@@ -11,7 +12,7 @@ public enum AutoModerator {
         }
 
         public static func `default`() -> Config {
-            return .init(triggerPhrases: [ // could these be simplified to "guys" ?
+            return .init(triggerPhrases: [
                 "you guys",
                 "thanks guys",
                 "hi guys",
@@ -20,6 +21,7 @@ public enum AutoModerator {
         }
     }
 }
+
 extension SlackBot {
     public func enableAutoModerator(config: AutoModerator.Config) -> SlackBot {
         listen(for: .message) { bot, message in
@@ -27,10 +29,14 @@ extension SlackBot {
             guard !(message.subtype == .thread_broadcast && message.hidden) else { return }
 
             try message.matching(.anyOf(config.triggerPhrases)) { _ in
-                let response: MarkdownString = "Maybe next time, consider using “y’all” or “folks” instead. It’s more inclusive than “guys”. \(.smile)"
+                let camilleLink = URL(string: "https://iosfolks.com/camille")!
+                let heyGuysLink = URL(string: "https://iosfolks.com/hey-guys")!
+                let communityGuideLink = URL(string: "https://iosfolks.com/guide")!
+                let response: MarkdownString = "To promote inclusivity we ask people to use an alternative to guys such as y’all or folks. We all make mistakes so don't overthink it, you can learn more about \("this message", heyGuysLink) or \("Camille", camilleLink) in our \("Community Guide", communityGuideLink)."
                 try bot.perform(.respond(to: message, .threaded, with: response))
             }
         }
+
         return self
     }
 }

--- a/Sources/SlackBotKit/Camillink/Camillink+Tracking.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+Tracking.swift
@@ -18,13 +18,14 @@ extension SlackBot.Camillink {
             case let record?:
                 if isRecordExpired(config, record) {
                     try storage.remove(forKey: link.absoluteString, from: Keys.namespace)
-
                 } else if !shouldSilence(link, config, message, record) {
                     let response: MarkdownString = "\(.wave) That \("link", link) is also being discussed in \("this message", record.permalink) in \(record.channelID)"
                     try bot.perform(.respond(to: message, .threaded, with: response))
                 }
 
             case nil: // new link
+                guard !shouldSilenceForAllowListedDomain(link) else { return }
+
                 let permalink = try bot.perform(.permalink(for: message))
                 let record = Record(date: config.dateFactory(), channelID: permalink.channel, permalink: permalink.permalink)
                 try storage.set(forKey: link.absoluteString, from: Keys.namespace, value: record)
@@ -54,7 +55,8 @@ extension SlackBot.Camillink {
             "apple.com",
             "developer.apple.com",
             "iosdevelopers.slack.com",
-            "iosfolks.com"
+            "iosfolks.com",
+            "mlb.tv"
         ]
 
         guard let components = URLComponents(url: link, resolvingAgainstBaseURL: false) else { return false }

--- a/Sources/SlackBotKit/Camillink/Camillink+Tracking.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+Tracking.swift
@@ -8,7 +8,7 @@ extension SlackBot.Camillink {
         let links = message.links()
             .filter({ $0.url.absoluteString.hasPrefix("http") })
             .map({ $0.url })
-            .compactMap({ self.removeGarbageQueryParameter(url: $0) })
+            .compactMap({ self.removeGarbageQueryParameters(url: $0) })
             .removeDuplicates()
 
         guard !links.isEmpty else { return }
@@ -66,8 +66,8 @@ extension SlackBot.Camillink {
         return message.channel == record.channelID
     }
 
-    private static func removeGarbageQueryParameter(url: URL) -> URL? {
-        let denyListedQueryItems = [
+    private static func removeGarbageQueryParameters(url: URL) -> URL? {
+        let denyListedQueryParameters = [
             "utm",
             "utm_source",
             "utm_media",
@@ -82,7 +82,7 @@ extension SlackBot.Camillink {
         guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
 
         urlComponents.queryItems?.removeAll(where: { queryItem in
-            denyListedQueryItems.contains(where: { $0 == queryItem.name })
+            denyListedQueryParameters.contains(where: { $0 == queryItem.name })
         })
 
         if let queryItems = urlComponents.queryItems, queryItems.isEmpty {

--- a/Sources/SlackBotKit/Camillink/Camillink+Tracking.swift
+++ b/Sources/SlackBotKit/Camillink/Camillink+Tracking.swift
@@ -53,6 +53,7 @@ extension SlackBot.Camillink {
         let allowListedHosts = [
             "apple.com",
             "developer.apple.com",
+            "iosdevelopers.slack.com",
             "iosfolks.com"
         ]
 

--- a/Sources/SlackBotKit/Karma/Karma+Adjustment.swift
+++ b/Sources/SlackBotKit/Karma/Karma+Adjustment.swift
@@ -6,17 +6,20 @@ struct KarmaModifier {
 
 extension ElementMatcher {
     static var karma: ElementMatcher {
+        // We don't want users to spam the karma system so increments and decrements are capped to 10
+        let maxKarmaChangeCap = 10
+
         let plusStart = Parser.literal("++").map { _ in 1 }
         let plusExtra = Parser<Int>.char("+").many.optional.map { $0?.count ?? 0 }
         let plusses = (plusStart && plusExtra).map { $0 + $1 }
-        let plusPlus = ElementMatcher(^plusses).map { n in KarmaModifier { $0 + n } }
-        let plusEqualN = ElementMatcher("+=" && optional(.whitespace) *> .integer).map { n in KarmaModifier { $0 + n } }
+        let plusPlus = ElementMatcher(^plusses).map { n in KarmaModifier { $0 + min(n, maxKarmaChangeCap) } }
+        let plusEqualN = ElementMatcher("+=" && optional(.whitespace) *> .integer).map { n in KarmaModifier { $0 + min(n, maxKarmaChangeCap) } }
 
         let minusStart = Parser.literal("--").map { _ in 1 }
         let minusExtra = Parser<Int>.char("-").many.optional.map { $0?.count ?? 0 }
         let minuses = (minusStart && minusExtra).map { $0 + $1 }
-        let minusMinus = ElementMatcher(^minuses).map { n in KarmaModifier { $0 - n } }
-        let minusEqualN = ElementMatcher("-=" && optional(.whitespace) *> .integer).map { n in KarmaModifier { $0 - n } }
+        let minusMinus = ElementMatcher(^minuses).map { n in KarmaModifier { $0 - min(n, maxKarmaChangeCap) } }
+        let minusEqualN = ElementMatcher("-=" && optional(.whitespace) *> .integer).map { n in KarmaModifier { $0 - min(n, maxKarmaChangeCap) } }
 
         return plusPlus || plusEqualN || minusMinus || minusEqualN
     }

--- a/Sources/SlackBotKit/Karma/Karma+Adjustment.swift
+++ b/Sources/SlackBotKit/Karma/Karma+Adjustment.swift
@@ -6,13 +6,19 @@ struct KarmaModifier {
 
 extension ElementMatcher {
     static var karma: ElementMatcher {
-        let plusOne = ElementMatcher(^"++").map(KarmaModifier { $0 + 1 })
-        let plusN = ElementMatcher("+=" && optional(.whitespace) *> .integer).map { n in KarmaModifier { $0 + n } }
+        let plusStart = Parser.literal("++").map { _ in 1 }
+        let plusExtra = Parser<Int>.char("+").many.optional.map { $0?.count ?? 0 }
+        let plusses = (plusStart && plusExtra).map { $0 + $1 }
+        let plusPlus = ElementMatcher(^plusses).map { n in KarmaModifier { $0 + n } }
+        let plusEqualN = ElementMatcher("+=" && optional(.whitespace) *> .integer).map { n in KarmaModifier { $0 + n } }
 
-        let minusOne = ElementMatcher(^"--").map(KarmaModifier { $0 - 1 })
-        let minusN = ElementMatcher("-=" && optional(.whitespace) *> .integer).map { n in KarmaModifier { $0 - n } }
+        let minusStart = Parser.literal("--").map { _ in 1 }
+        let minusExtra = Parser<Int>.char("-").many.optional.map { $0?.count ?? 0 }
+        let minuses = (minusStart && minusExtra).map { $0 + $1 }
+        let minusMinus = ElementMatcher(^minuses).map { n in KarmaModifier { $0 - n } }
+        let minusEqualN = ElementMatcher("-=" && optional(.whitespace) *> .integer).map { n in KarmaModifier { $0 - n } }
 
-        return plusOne || plusN || minusOne || minusN
+        return plusPlus || plusEqualN || minusMinus || minusEqualN
     }
 }
 

--- a/Tests/SlackBotKitTests/CamillinkTests.swift
+++ b/Tests/SlackBotKitTests/CamillinkTests.swift
@@ -4,6 +4,7 @@ import ChameleonTestKit
 import XCTest
 
 class CamillinkTests: XCTestCase {
+
     func testLinkTracking() throws {
         let test = try SlackBot.test()
         let storage = MemoryStorage()
@@ -51,6 +52,13 @@ class CamillinkTests: XCTestCase {
         date.addTimeInterval(1)
         try test.enqueue([.emptyMessage()])
         try test.send(.event(.message([.link(url: URL("https://twitter.com/IanKay"))])))
+        try XCTAssertEqual(storage.keys(in: SlackBot.Camillink.Keys.namespace), ["https://twitter.com/IanKay"])
+        XCTAssertClear(test)
+
+        // same link, ensuring a denylisted query parameter is stripped, 1 second later
+        date.addTimeInterval(1)
+        try test.enqueue([.emptyMessage()])
+        try test.send(.event(.message([.link(url: URL("https://twitter.com/IanKay?s=20"))])))
         try XCTAssertEqual(storage.keys(in: SlackBot.Camillink.Keys.namespace), ["https://twitter.com/IanKay"])
         XCTAssertClear(test)
 

--- a/Tests/SlackBotKitTests/CamillinkTests.swift
+++ b/Tests/SlackBotKitTests/CamillinkTests.swift
@@ -55,6 +55,12 @@ class CamillinkTests: XCTestCase {
         try XCTAssertEqual(storage.keys(in: SlackBot.Camillink.Keys.namespace), ["https://twitter.com/IanKay"])
         XCTAssertClear(test)
 
+        // same link, ensuring that an allowlisted domain does not trigger Camille, 1 second later
+        date.addTimeInterval(1)
+        try test.send(.event(.message([.link(url: URL("https://apple.com/"))])))
+        try XCTAssertEqual(storage.keys(in: SlackBot.Camillink.Keys.namespace), ["https://twitter.com/IanKay"])
+        XCTAssertClear(test)
+
         // same link, ensuring a denylisted query parameter is stripped, 1 second later
         date.addTimeInterval(1)
         try test.enqueue([.emptyMessage()])

--- a/Tests/SlackBotKitTests/KarmaTests.swift
+++ b/Tests/SlackBotKitTests/KarmaTests.swift
@@ -128,4 +128,20 @@ class KarmaTests: XCTestCase {
         try XCTAssertEqual(storage.get(forKey: "1", from: SlackBot.Karma.Keys.namespace), 1)
         XCTAssertClear(test)
     }
+
+    func testKarma_PointsCapped() throws {
+        let test = try SlackBot.test()
+        let storage = MemoryStorage()
+        _ = test.bot.enableKarma(config: .default(), storage: storage)
+
+        // 20 pluses and minuses should be capped at 10
+        try test.send(.event(.message([.user("1"), .text(" ++++++++++++++++++++++")])), enqueue: [.emptyMessage()])
+        try test.send(.event(.message([.user("2"), .text(" ----------------------")])), enqueue: [.emptyMessage()])
+
+        try XCTAssertEqual(storage.keys(in: SlackBot.Karma.Keys.namespace), ["1", "2"])
+        try XCTAssertEqual(storage.get(forKey: "1", from: SlackBot.Karma.Keys.namespace), 10)
+        try XCTAssertEqual(storage.get(forKey: "2", from: SlackBot.Karma.Keys.namespace), -10)
+        XCTAssertClear(test)
+    }
+
 }


### PR DESCRIPTION
- Adding multiple pluses or minuses is now a fun shorthand for +=, such as @mergesort+++ to give two points.

- Changing the threaded Camille message to be gentler and provide more context for users that are unfamiliar with Camille.

- Creating an allowlist of domains that will not trigger Camille. (Please provide feedback on domains you'd like to see be added.)

- Removing garbage query parameters to resolve duplicate links with different query parameters. (Standard UTM parameters and Twitter-specific parameters, but happy to add more.)

- Updating the Camille README to make it easier for anyone else to get started with Camille development.